### PR TITLE
Authenticate with central registry

### DIFF
--- a/src/main/java/in/org/projecteka/hiu/dataflow/DataFlowRequestListener.java
+++ b/src/main/java/in/org/projecteka/hiu/dataflow/DataFlowRequestListener.java
@@ -37,7 +37,6 @@ public class DataFlowRequestListener {
     private final DataFlowProperties dataFlowProperties;
     private final CentralRegistry centralRegistry;
 
-
     @PostConstruct
     @SneakyThrows
     public void subscribe() {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -9,9 +9,9 @@ hiu:
     maxPageSize: 100
     localStoragePath: /tmp/
   centralregistry:
-    url: http://localhost:9001/auth
+    url: http://host.docker.internal:8080
     clientId: 10000005
-    clientSecret: 435cbced-9d57-4e35-9de8-0c2315d841df
+    clientSecret: b435af20-5006-4932-bca7-74aabdf8a78d
   database:
     host: localhost
     port: 5432


### PR DESCRIPTION
* Don't merge it.
* Earlier it was authenticating with key cloak, now it will authenticate with central registry before calls Consent Manager
* In Consent Manager, some APIs can only be called with the token which any entity get from central registry.